### PR TITLE
Improve zero row handling.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ include make.inc
 # Set the optimization level. I prefer '-O3'.
 #opt = 
 #opt = -g
-opt = -O3
+opt = -g -O3
 
 # Choose serial, OpenMP-parallelized, MPI-parallized versions, or hybrid
 # MPI-OpenMP. I prefer OpenMP to MPI if I'm running on one shared-memory
@@ -80,23 +80,23 @@ libhmmvp: $(OBJECTS)
 	ar rucs lib/libhmmvp_$(mode).a $(OBJECTS)
 
 # A driver to compress an H-matrix.
-build: libhmmvp
-	$(CPP) src/hmmvpbuild.cpp $(INCLUDE) $(LDFLAGS) $(LIBFLAGS) $(LIBDIRS) lib/libhmmvp_$(mode).a $(LIBS) -o bin/hmmvpbuild_$(mode)
+build: libhmmvp src/hmmvpbuild.o
+	$(CPP) $(LDFLAGS) $(LIBFLAGS) $(LIBDIRS) src/hmmvpbuild.o lib/libhmmvp_$(mode).a $(LIBS) -o bin/hmmvpbuild_$(mode)
 
 # C++ examples.
-mvp:
-	$(CPP) examples/mvp_$(ext).cpp $(INCLUDE) $(LDFLAGS) $(LIBFLAGS) $(LIBDIRS) lib/libhmmvp_$(mode).a $(LIBS) -o examples/mvp_$(mode)
+mvp: libhmmvp examples/mvp_$(ext).o
+	$(CPP) $(LDFLAGS) $(LIBFLAGS) $(LIBDIRS) examples/mvp_$(ext).o lib/libhmmvp_$(mode).a $(LIBS) -o examples/mvp_$(mode)
 
 # C example.
-cmvp:
+cmvp: libhmmvp
 ifneq ($(ext),mpi)
-	$(CPP) examples/cmvp_$(ext).c $(INCLUDE) $(LDFLAGS) $(LIBFLAGS) $(LIBDIRS) lib/libhmmvp_$(mode).a $(LIBS) -o examples/cmvp_$(mode)
+	$(CPP) examples/cmvp_$(ext).c $(INCLUDE) $(CPPFLAGS) $(LDFLAGS) $(LIBFLAGS) $(LIBDIRS) lib/libhmmvp_$(mode).a $(LIBS) -o examples/cmvp_$(mode)
 endif
 
 # Fortran 90 example.
-fmvp:
+fmvp: libhmmvp
 ifneq ($(ext),mpi)
-	$(FORTRAN) examples/fmvp_$(ext).f90 $(INCLUDE) $(LDFLAGS) lib/libhmmvp_$(mode).a $(LIBS) -lstdc++ -o examples/fmvp_$(mode)
+	$(FORTRAN) examples/fmvp_$(ext).f90 $(INCLUDE) $(FFLAGS) $(LDFLAGS) lib/libhmmvp_$(mode).a $(LIBS) -lstdc++ -o examples/fmvp_$(mode)
 endif
 
 clean:

--- a/examples/fmvp_omp.f90
+++ b/examples/fmvp_omp.f90
@@ -42,9 +42,9 @@ program main
 
   call getarg(1, filename)
   call getarg(2, arg)
-  read(arg, '(i10)'), nthreads
+  read(arg, '(i10)') nthreads
   call getarg(3, arg)
-  read(arg, '(i10)'), repeat
+  read(arg, '(i10)') repeat
 
   ! Initialize the H-matrix.
   ncol = 1

--- a/hmmvp/include/Compress.hpp
+++ b/hmmvp/include/Compress.hpp
@@ -89,6 +89,10 @@ public:
   bool IsMrem() const;
   // Set tol. Default is 1e-6.
   void SetTol(double tol) throw (Exception);
+  // Set the number of 0 rows in a block that are permitted before ACA exits. If
+  // ACA finds a non-0 row, it resets the zero-row counter. Default: 2. n <= 0
+  // means 0.
+  void SetNumberOfRejectedZeroRowsBeforeStopping(int n);
 
   // Using an old H-matrix.
 

--- a/make-depends.sh
+++ b/make-depends.sh
@@ -1,0 +1,4 @@
+for i in src/*.cpp; do
+    printf "src/"
+    g++ -I. -MM $i
+done > make.depends

--- a/make.depends
+++ b/make.depends
@@ -1,0 +1,47 @@
+src/CHmat.o: src/CHmat.cpp hmmvp/include/Hmat.hpp util/include/Exception.hpp \
+ util/include/Defs.hpp util/include/Matrix.hpp util/include/IO.hpp
+src/CodeAnalysis.o: src/CodeAnalysis.cpp util/include/CodeAnalysis.hpp
+src/Compress.o: src/Compress.cpp util/include/Mpi.hpp util/include/OpenMP.hpp \
+ util/include/Mpi_inl.hpp util/include/CodeAnalysis.hpp \
+ util/include/Util.hpp util/include/Exception.hpp util/include/Matrix.hpp \
+ util/include/IO.hpp hmmvp/include/Hmat.hpp util/include/Defs.hpp \
+ hmmvp/include/HmatIo.hpp hmmvp/include/HmatIo_inl.hpp src/Hd_pri.hpp \
+ src/Compress_pri.hpp src/Compress_inl.hpp util/include/LinAlg.hpp \
+ util/include/WorkArray.hpp util/include/LinAlg_inl.hpp
+src/GreensFnInverseR.o: src/GreensFnInverseR.cpp
+src/Hd.o: src/Hd.cpp util/include/Util.hpp util/include/Exception.hpp \
+ util/include/Matrix.hpp util/include/IO.hpp util/include/LinAlg.hpp \
+ util/include/Defs.hpp util/include/WorkArray.hpp \
+ util/include/LinAlg_inl.hpp src/Hd_pri.hpp
+src/Hmat.o: src/Hmat.cpp util/include/Util.hpp util/include/Exception.hpp \
+ util/include/Matrix.hpp util/include/IO.hpp util/include/OpenMP.hpp \
+ util/include/LinAlg.hpp util/include/Defs.hpp util/include/WorkArray.hpp \
+ util/include/LinAlg_inl.hpp hmmvp/include/HmatIo.hpp \
+ hmmvp/include/Hmat.hpp hmmvp/include/HmatIo_inl.hpp
+src/HmatIo.o: src/HmatIo.cpp util/include/Util.hpp util/include/Exception.hpp \
+ util/include/Matrix.hpp util/include/IO.hpp hmmvp/include/HmatIo.hpp \
+ util/include/Defs.hpp hmmvp/include/Hmat.hpp \
+ hmmvp/include/HmatIo_inl.hpp
+src/hmmvpbuild.o: src/hmmvpbuild.cpp util/include/Mpi.hpp \
+ util/include/OpenMP.hpp util/include/Mpi_inl.hpp \
+ util/include/CodeAnalysis.hpp util/include/KeyValueFile.hpp \
+ util/include/Exception.hpp util/include/Matrix.hpp util/include/IO.hpp \
+ util/include/Util.hpp hmmvp/include/Hd.hpp util/include/Defs.hpp \
+ hmmvp/include/Compress.hpp hmmvp/include/Hmat.hpp src/Help.hpp \
+ src/GreensFnInverseR.cpp
+src/KeyValueFile.o: src/KeyValueFile.cpp util/include/Defs.hpp \
+ src/KeyValueFile_pri.hpp util/include/Exception.hpp \
+ util/include/Matrix.hpp util/include/IO.hpp
+src/Mpi.o: src/Mpi.cpp util/include/Mpi.hpp util/include/OpenMP.hpp \
+ util/include/Mpi_inl.hpp util/include/CodeAnalysis.hpp
+src/PolyInterp.o: src/PolyInterp.cpp util/include/PolyInterp.hpp \
+ util/include/Matrix.hpp util/include/Exception.hpp util/include/IO.hpp
+src/SFHmat.o: src/SFHmat.cpp hmmvp/include/Hmat.hpp \
+ util/include/Exception.hpp util/include/Defs.hpp util/include/Matrix.hpp \
+ util/include/IO.hpp hmmvp/include/SFHmat.h
+src/ValueSetter.o: src/ValueSetter.cpp util/include/ValueSetter.hpp \
+ util/include/Defs.hpp util/include/ValueSetter_inl.hpp \
+ util/include/KeyValueFile.hpp util/include/Exception.hpp \
+ util/include/Matrix.hpp util/include/IO.hpp util/include/Mpi.hpp \
+ util/include/OpenMP.hpp util/include/Mpi_inl.hpp \
+ util/include/CodeAnalysis.hpp

--- a/src/Compress_pri.hpp
+++ b/src/Compress_pri.hpp
@@ -102,7 +102,8 @@ class AcaGfHolder;
 template<typename T>
 void Aca(const MatBlock& blk, MatrixAccessor& ma, double scale,
          const bool use_rel_err, const double err,
-         Matrix<T>& U, Matrix<T>& V, AcaGfHolder* gh = NULL)
+         Matrix<T>& U, Matrix<T>& V, AcaGfHolder* gh = NULL,
+         const int n_permitted_zero_rows = 2)
   throw (OutOfMemoryException, UserReqException);
 
 // Recompression using the QR factorization.
@@ -118,11 +119,13 @@ struct LraOptions {
   double aca_tol_factor;
   UInt min_aca_size;
   bool avoid_redundant_gf_evals;
+  int n_permitted_zero_rows;
   bool call_CompressQr, allow_0rank;
   static const double qr_alpha;
 
   LraOptions() : method(lra_aca), aca_tol_factor(0.1), min_aca_size(16),
-                 avoid_redundant_gf_evals(false), call_CompressQr(true) {}
+                 n_permitted_zero_rows(2), avoid_redundant_gf_evals(false),
+                 call_CompressQr(true) {}
 };
 
 template<typename T>
@@ -209,6 +212,7 @@ public:
   TolMethod GetTolMethod() const;
   bool IsMrem() const;
   void SetTol(double tol) throw (Exception);
+  void SetNumberOfRejectedZeroRowsBeforeStopping(int n);
   void SetBfroEstimate(double Bfro) throw (Exception);
   double GetBfroEstimate() const;
   // Use another H-matrix file to speed up compressing this one. Returns false
@@ -261,6 +265,7 @@ private:
   TolMethod _tm;
   double _Bfro;
   double _tol;
+  int _n_permitted_zero_rows;
   bool _user_set_prec;
   bool _avoid_redundant_gf_evals, _call_CompressQr;
   bool _allow_0rank;


### PR DESCRIPTION
Improve handling of blocks having fully 0 rows. The new option SetNumberOfRejectedZeroRowsBeforeStopping(n) sets the number of fully 0 rows ACA will accept before, on the next one, exiting. It resets the 0-row counter each time it finds a non-0 row; thus, the total number of 0-rows in the block can be > n without causing an exit.

Also clean up the Makefile.